### PR TITLE
docs(45d-drivemap): describe v0.4.0 hardware support

### DIFF
--- a/limetech/45d-drivemap.xml
+++ b/limetech/45d-drivemap.xml
@@ -7,9 +7,9 @@
 <Category>Tools:System</Category>
 <Name>45D Drive Map</Name>
 <MinVer>6.12.0</MinVer>
-<Requires>45Drives system, such as an X-15 or HL-15</Requires>
+<Requires>45Drives X-15, HL-15, HL-8, HL-4, or Unraid 45Homelab X-4 system</Requires>
 <Description>
-Embed the 45Drives disk map UI directly in Unraid's Main page and generate map/server metadata on the Unraid host. This plugin is supported on 45Drives systems only, such as X-15 and HL-15 systems.
+Embed the 45Drives disk map UI directly in Unraid's Main page and generate map/server metadata on the Unraid host. Standard X-15, HL-15 1.0/2.0, HL-8, HL-4, and Unraid 45Homelab X-4 systems are detected automatically. HL-15 systems with non-standard motherboard/HBA wiring may require a manual HBA phy-order override; see Support for configuration details.
 </Description>
 <Support>https://github.com/unraid/45d-drivemap/issues</Support>
 <IconFA>th</IconFA>

--- a/limetech/45d-drivemap.xml
+++ b/limetech/45d-drivemap.xml
@@ -7,10 +7,11 @@
 <Category>Tools:System</Category>
 <Name>45D Drive Map</Name>
 <MinVer>6.12.0</MinVer>
-<Requires>45Drives X-15, HL-15, HL-8, HL-4, or Unraid 45Homelab X-4 system</Requires>
+<Requires>45Drives X-15, HL-15 1.0/2.0, HL-8, HL-4, or Unraid 45Homelab X-4 system</Requires>
 <Description>
-Embed the 45Drives disk map UI directly in Unraid's Main page and generate map/server metadata on the Unraid host. Standard X-15, HL-15 1.0/2.0, HL-8, HL-4, and Unraid 45Homelab X-4 systems are detected automatically. HL-15 systems with non-standard motherboard/HBA wiring may require a manual HBA phy-order override; see Support for configuration details.
+Embed the 45Drives disk map UI directly in Unraid's Main page and generate map/server metadata on the Unraid host. Standard X-15, HL-15 1.0/2.0, HL-8, HL-4, and Unraid 45Homelab X-4 systems are detected automatically. HL-15 systems with non-standard motherboard/HBA wiring may require a manual HBA phy-order override; see the project README for configuration details.
 </Description>
 <Support>https://github.com/unraid/45d-drivemap/issues</Support>
+<Project>https://github.com/unraid/45d-drivemap#configuration-overrides</Project>
 <IconFA>th</IconFA>
 </Containers>


### PR DESCRIPTION
## Summary
The Community Apps entry still described the pre-v0.4.0 hardware scope; this updates it to advertise the released compact-system support while calling out the override requirement for non-standard HL-15 wiring.

## Why This Exists
Version 0.4.0 of `45d-drivemap` adds automatic mapping for HL-4, HL-8, and Unraid 45Homelab X-4 systems alongside the existing X-15 and HL-15 support. The existing template only names X-15 and HL-15, so users cannot tell which configurations are now detected automatically or when manual setup is still required.

## Resolution
Expand the `Requires` and `Description` fields to list the supported systems and explain that standard configurations are automatically detected. Link the Project metadata directly to the README's Configuration Overrides section for non-standard HL-15 wiring. Keep the existing product name because the released plugin now supports multiple 45Drives and 45Homelab models.

## Reviewer Considerations
- Confirm the hardware list matches the v0.4.0 changelog: X-15, HL-15 1.0/2.0, HL-8, HL-4, and Unraid 45Homelab X-4.
- Confirm the non-standard HL-15 wording and Project link accurately direct users toward the documented HBA phy-order override without implying that factory configurations need manual setup.
- The template continues to use the stable `releases/latest` plugin URL, so no version-specific URL change is required.

## Behavior Changes
Community Apps will show the expanded v0.4.0 support matrix and the manual-override caveat before installation.

## Implementation Summary
- Updated the 45D Drive Map hardware requirements.
- Updated the description for automatic detection and non-standard HL-15 wiring.
- Linked the Project field to the README's Configuration Overrides section.

## Verification
- `xmllint --noout limetech/45d-drivemap.xml`
- `git diff --check`

## Risk
Low; this changes catalog metadata only and leaves the plugin installation URL and runtime behavior unchanged.
